### PR TITLE
This PR introduces release and prerelease in the GitHub Actions workflows:

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,66 @@
+name: Pre-release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - '!v*.*.*-pre*'  # Only match stable releases
+
+  workflow_dispatch:
+
+jobs:
+  generate-prerelease:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git identity
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+
+      - name: Compute next pre-release version
+        id: prerelease
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          BASE_VERSION="${TAG#v}"
+          
+          # Extract major.minor.patch
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+          NEXT_PATCH=$((PATCH + 1))
+
+          # Add timestamp to differentiate pre-releases
+          STAMP=$(date +%Y%m%d%H%M%S)
+          PRE_TAG="v${MAJOR}.${MINOR}.${NEXT_PATCH}-pre.${STAMP}"
+
+          echo "Generated pre-release tag: $PRE_TAG"
+          echo "PRE_TAG=$PRE_TAG" >> $GITHUB_ENV
+
+      - name: Create and push pre-release tag
+        run: |
+          git tag -a "$PRE_TAG" -m "Auto pre-release after $GITHUB_REF"
+          git push origin "$PRE_TAG"
+
+      - name: Publish GitHub Pre-release
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          tag_name: ${{ env.PRE_TAG }}
+          prerelease: true
+          name: Pre-release ${{ env.PRE_TAG }}
+          body: |
+            This is an automated pre-release following ${{ github.ref_name }}.
+
+            ## Docker Image
+            ghcr.io/${{ github.repository }}:${{ env.PRE_TAG }}
+
+            ### Pull:
+            ```bash
+            docker pull ghcr.io/${{ github.repository }}:${{ env.PRE_TAG }}
+            ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and Release
+name: Release
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME_FRONTEND: app-frontend
-  IMAGE_NAME_SERVICE: app-service
+  IMAGE_NAME: app
 
 jobs:
   build-and-release:
@@ -31,8 +30,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          install: true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -52,7 +49,7 @@ jobs:
 
       - name: Build and push app image
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/app"
+          IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}"
           IMAGE=$(echo "$IMAGE" | tr '[:upper:]' '[:lower:]')
           VERSION="${{ steps.version.outputs.version }}"
 
@@ -65,18 +62,16 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: ${{ contains(github.ref_name, '-pre') }}
           name: Release ${{ github.ref_name }}
           body: |
-            ## Docker Images
+            ## Docker Image
 
-            - `${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_FRONTEND }}:${{ steps.version.outputs.version }}`
-            - `${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_SERVICE }}:${{ steps.version.outputs.version }}`
+            - `${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}`
 
             ## Pull example
 
             ```bash
-            docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_SERVICE }}:${{ steps.version.outputs.version }}
+            docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
             ```
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - cristian-release-prerelease
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-pre*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine release version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
             -t $IMAGE:$VERSION \
             --push .
 
+
       - name: Create GitHub Release (if tagged)
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,14 @@
-name: Release
+name: Build and Release
+
 on:
   push:
     branches:
       - main
-      - cristian-a3
-    tags: ['v[0-9]+.[0-9]+.[0-9]+']
+      - cristian-release-prerelease
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-pre*'
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -12,37 +16,80 @@ env:
   IMAGE_NAME_SERVICE: app-service
 
 jobs:
-  build:
+  build-and-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
-    steps:
-      - uses: actions/checkout@v4
 
-      - uses: docker/login-action@v3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
         with:
-          registry: ghcr.io
+          install: true
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GH_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build and push multi-platform Docker image
+      - name: Determine release version
+        id: version
         run: |
-          IMG="ghcr.io/${{ github.repository }}"
-          IMG=$(echo "$IMG" | tr '[:upper:]' '[:lower:]')
-          echo "Final image name: $IMG"
-
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-            docker buildx build --platform linux/amd64,linux/arm64 \
-              -t $IMG:latest \
-              -t $IMG:$VERSION \
-              --push .
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           else
-            docker buildx build --platform linux/amd64,linux/arm64 \
-              -t $IMG:latest \
-              --push .
+            echo "version=latest" >> $GITHUB_OUTPUT
           fi
+
+      - name: Build and push frontend image
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_FRONTEND }}"
+          IMAGE=$(echo "$IMAGE" | tr '[:upper:]' '[:lower:]')
+          VERSION="${{ steps.version.outputs.version }}"
+
+          docker buildx build --platform linux/amd64,linux/arm64 \
+            -f Dockerfile.frontend \
+            -t $IMAGE:latest \
+            -t $IMAGE:$VERSION \
+            --push .
+
+      - name: Build and push service image
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_SERVICE }}"
+          IMAGE=$(echo "$IMAGE" | tr '[:upper:]' '[:lower:]')
+          VERSION="${{ steps.version.outputs.version }}"
+
+          docker buildx build --platform linux/amd64,linux/arm64 \
+            -f Dockerfile.service \
+            -t $IMAGE:latest \
+            -t $IMAGE:$VERSION \
+            --push .
+
+      - name: Create GitHub Release (if tagged)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          prerelease: ${{ contains(github.ref_name, '-pre') }}
+          name: Release ${{ github.ref_name }}
+          body: |
+            ## Docker Images
+
+            - `${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_FRONTEND }}:${{ steps.version.outputs.version }}`
+            - `${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_SERVICE }}:${{ steps.version.outputs.version }}`
+
+            ## Pull example
+
+            ```bash
+            docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_SERVICE }}:${{ steps.version.outputs.version }}
+            ```
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_TOKEN }}
 
       - name: Determine release version
         id: version
@@ -63,7 +63,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
           prerelease: ${{ contains(github.ref_name, '-pre') }}
           name: Release ${{ github.ref_name }}
           body: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,26 +50,13 @@ jobs:
             echo "version=latest" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build and push frontend image
+      - name: Build and push app image
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_FRONTEND }}"
+          IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/app"
           IMAGE=$(echo "$IMAGE" | tr '[:upper:]' '[:lower:]')
           VERSION="${{ steps.version.outputs.version }}"
 
           docker buildx build --platform linux/amd64,linux/arm64 \
-            -f Dockerfile.frontend \
-            -t $IMAGE:latest \
-            -t $IMAGE:$VERSION \
-            --push .
-
-      - name: Build and push service image
-        run: |
-          IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_SERVICE }}"
-          IMAGE=$(echo "$IMAGE" | tr '[:upper:]' '[:lower:]')
-          VERSION="${{ steps.version.outputs.version }}"
-
-          docker buildx build --platform linux/amd64,linux/arm64 \
-            -f Dockerfile.service \
             -t $IMAGE:latest \
             -t $IMAGE:$VERSION \
             --push .


### PR DESCRIPTION
release.yml – Official Release Pipeline

Trigger: Runs when a tag matching vX.Y.Z (e.g. v1.0.0) is pushed.
Actions:
Parses version number from the tag.
Builds a multi-arch Docker image.
Pushes the image to GHCR with multiple semantic version tags: :latest, :1-latest, :1.0-latest, :1.0.0
Creates a GitHub Release.

pre-release.yml – Automated Pre-release Pipeline
Increments the patch version (e.g., from v1.0.0 → v1.0.1-pre-YYYYMMDD-).
Builds and pushes a Docker image tagged with the computed pre-release version.
Pushes a new Git tag for the pre-release.
Creates a GitHub pre-release with metadata and Docker image reference.